### PR TITLE
Define path to coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ script:
 after_success:
     - bash run_coverage.sh
     # Upload report to codecov
-    - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+    - bash <(curl -s https://codecov.io/bash) -f ./coverage.info || echo "Codecov did not collect coverage reports"


### PR DESCRIPTION
Force codecov to read the specific code coverage report
which we have already generated so to enforce the ignored
filepaths list. Alternatively, which is actually the suggested
way of doing this, one should create a `.codecov.yml` file as
described [here](https://docs.codecov.io/v4.3.6/docs/ignoring-paths).
However, since we probably don't want to completely rely on
codecov.io services to generate our reports AND we do not want to
keep duplicate ignore path lists (i.e. one in the `run_coverage.sh`
script and one in `.codecov.yml`) we explicitely instruct
codecov which coverage report it should use, instead of freely
roaming over our project's files and generating reports for files
we don't care.

Fixes #42 