### PR TITLE
Add helper functions to DataStore

### DIFF
--- a/server/include/data_store.hpp
+++ b/server/include/data_store.hpp
@@ -44,7 +44,7 @@ public:
     bool AssignDeviceToEmployee(const std::string& device_id, const std::string& employee_id);
 
     bool InsertRSSIReadings(const std::string& device_id,
-                            std::vector<std::pair<std::string, double>> macaddr_rssi_datapoints);
+                            std::vector<std::pair<std::string, int32_t>> macaddr_rssi_datapoints);
 
     bool GetPosition(const std::string& device_id, QueryT queryby, Position& pos);
 

--- a/server/include/data_store.hpp
+++ b/server/include/data_store.hpp
@@ -8,8 +8,6 @@
 #include <iostream>
 #include <spdlog/spdlog.h>
 #include <sqlite3.h>
-#include <string>
-#include <vector>
 
 #include "types.hpp"
 
@@ -52,6 +50,12 @@ public:
 
     bool ClearDeviceTable(const std::string& device_id);
 
+    std::vector<std::string> ReadDistinctMacAddrs(const std::string& device_id);
+
+    std::vector<int32_t> GetRSSISeriesData(const std::string& device_id, const std::string& mac_addr);
+
+    std::vector<MacRssiList> GetRSSISeriesData(const std::string& device_id, std::vector<std::string> mac_addrs);
+
 private:
     bool CreateLocationTable();
 
@@ -59,7 +63,6 @@ private:
 
     static int DbCallback(void* not_used, int argc, char** argv, char** azColName);
 
-    std::vector<std::string> ReadDistinctMacAddrs(const std::string& device_id);
 
     sqlite3*                        database_;
     std::mutex                      database_lock_;

--- a/server/include/localization.hpp
+++ b/server/include/localization.hpp
@@ -6,8 +6,6 @@
 #define INS_SERVER_INS_INCLUDE_LOCALIZATION_HPP
 
 #include <spdlog/spdlog.h>
-#include <string>
-#include <vector>
 
 #include "types.hpp"
 

--- a/server/include/types.hpp
+++ b/server/include/types.hpp
@@ -5,10 +5,17 @@
 #ifndef INS_SERVICE_INS_INCLUDE_TYPES_HPP
 #define INS_SERVICE_INS_INCLUDE_TYPES_HPP
 
+#include <utility>
+#include <string>
+#include <vector>
+
 namespace ins_service
 {
 
 #define LOGGER_NAME "INS-Server"
+
+typedef std::pair<std::string, int32_t> MacRssi;
+typedef std::pair<std::string, std::vector<int32_t>> MacRssiList;
 
 enum QueryT
 {

--- a/server/src/data_store.cpp
+++ b/server/src/data_store.cpp
@@ -110,7 +110,7 @@ bool DataStore::AssignDeviceToEmployee(const std::string& device_id, const std::
 }
 
 bool DataStore::InsertRSSIReadings(const std::string& device_id,
-                                   std::vector<std::pair<std::string, double>> macaddr_rssi_datapoints)
+                                   std::vector<std::pair<std::string, int32_t>> macaddr_rssi_datapoints)
 {
     console_->debug("+ DataStore::InsertRSSIReadings");
 

--- a/server/src/ins_service.cpp
+++ b/server/src/ins_service.cpp
@@ -93,7 +93,7 @@ void IndoorNavigationService::SetReceivedSignalStrengths(const Pistache::Rest::R
 
     std::string device_id = request.param(":device_id").as<std::string>();
 
-    std::vector<std::pair<std::string, int32_t>> data_points;
+    std::vector<MacRssi> data_points;
 
     auto data_point = std::make_pair<std::string, int32_t>(request.param(":mac_addr1").as<std::string>(),
                                                          request.param(":rssi1").as<int32_t>());

--- a/server/src/ins_service.cpp
+++ b/server/src/ins_service.cpp
@@ -93,10 +93,10 @@ void IndoorNavigationService::SetReceivedSignalStrengths(const Pistache::Rest::R
 
     std::string device_id = request.param(":device_id").as<std::string>();
 
-    std::vector<std::pair<std::string, double>> data_points;
+    std::vector<std::pair<std::string, int32_t>> data_points;
 
-    auto data_point = std::make_pair<std::string, double>(request.param(":mac_addr1").as<std::string>(),
-                                                         request.param(":rssi1").as<double>());
+    auto data_point = std::make_pair<std::string, int32_t>(request.param(":mac_addr1").as<std::string>(),
+                                                         request.param(":rssi1").as<int32_t>());
 
     data_points.push_back(data_point);
 
@@ -107,8 +107,8 @@ void IndoorNavigationService::SetReceivedSignalStrengths(const Pistache::Rest::R
         rssi_key << ":rssi" << i;
         if (request.hasParam(mac_addr_key.str()) && request.hasParam(rssi_key.str()))
         {
-            data_points.push_back(std::make_pair<std::string, double>(
-                request.param(mac_addr_key.str()).as<std::string>(), request.param(rssi_key.str()).as<double>()));
+            data_points.push_back(std::make_pair<std::string, int32_t>(
+                request.param(mac_addr_key.str()).as<std::string>(), request.param(rssi_key.str()).as<int32_t>()));
         }
         else
         {

--- a/server/src/localization.cpp
+++ b/server/src/localization.cpp
@@ -10,7 +10,7 @@ namespace ins_service
 Position Localization::ProcessRSSIDataSet(const std::string& device_id)
 {
     console_->debug("+ Localization::ProcessRSSIDataSet");
-
+    (void)device_id;
     Position pos{ 3.2, 5, 11 };
     console_->debug("- Localization::ProcessRSSIDataSet");
     return pos;

--- a/server/test/mocks/mock_data_store.cpp
+++ b/server/test/mocks/mock_data_store.cpp
@@ -30,7 +30,7 @@ bool DataStore::AssignDeviceToEmployee(const std::string& dev, const std::string
 }
 
 bool DataStore::InsertRSSIReadings(const std::string&       dev,
-                                   std::vector<std::pair<std::string, double>> data_points)
+                                   std::vector<std::pair<std::string, int32_t>> data_points)
 {
     EXPECT_TRUE(g_mocked_data_store_ != nullptr);
     return g_mocked_data_store_->InsertRSSIReadings(dev, data_points);

--- a/server/test/mocks/mock_data_store.cpp
+++ b/server/test/mocks/mock_data_store.cpp
@@ -60,4 +60,15 @@ std::vector<std::string> DataStore::ReadDistinctMacAddrs(const std::string& dev)
     return g_mocked_data_store_->ReadDistinctMacAddrs(dev);
 }
 
+std::vector<int32_t> DataStore::GetRSSISeriesData(const std::string& device_id, const std::string& mac_addr)
+{
+    EXPECT_TRUE(g_mocked_data_store_ != nullptr);
+    return g_mocked_data_store_->GetRSSISeriesData(device_id, mac_addr);
+}
+
+std::vector<MacRssiList> DataStore::GetRSSISeriesData(const std::string& device_id, std::vector<std::string> mac_addrs)
+{
+    EXPECT_TRUE(g_mocked_data_store_ != nullptr);
+    return g_mocked_data_store_->GetRSSISeriesData(device_id, mac_addrs);
+}
 } // ins_servvice

--- a/server/test/mocks/mock_data_store.hpp
+++ b/server/test/mocks/mock_data_store.hpp
@@ -34,6 +34,12 @@ public:
 
     MOCK_METHOD1(ReadDistinctMacAddrs, std::vector<std::string>(const std::string&));
 
+    MOCK_METHOD2(GetRSSISeriesData, std::vector<int32_t>(const std::string&, const std::string&));
+
+    MOCK_METHOD2(GetRSSISeriesData, std::vector<MacRssiList>(const std::string&, std::vector<std::string>));
+
+    // MOCK_METHOD2()
+
     ~MockDataStore()
     {
         g_mocked_data_store_ = nullptr;

--- a/server/test/mocks/mock_data_store.hpp
+++ b/server/test/mocks/mock_data_store.hpp
@@ -24,7 +24,7 @@ public:
 
     MOCK_METHOD2(AssignDeviceToEmployee, bool(const std::string&, const std::string&));
 
-    MOCK_METHOD2(InsertRSSIReadings, bool(const std::string&, std::vector<std::pair<std::string, double>> data_points));
+    MOCK_METHOD2(InsertRSSIReadings, bool(const std::string&, std::vector<std::pair<std::string, int32_t>> data_points));
 
     MOCK_METHOD3(GetPosition, bool(const std::string&, QueryT, Position&));
 

--- a/server/test/suite_data_store.cpp
+++ b/server/test/suite_data_store.cpp
@@ -198,16 +198,16 @@ TEST_F(DataStoreFixture, InsertRSSIReadings_WillFormSqlToInsertRSSIReadings)
 {
     data_store_->Init("db");
     std::string device_id = "4004";
-    std::vector<std::pair<std::string, double>> data_points;
-    data_points.push_back(std::make_pair<std::string, double>("ee:44:43:a5:ff:ef", 23.66));
-    data_points.push_back(std::make_pair<std::string, double>("11:65:d4:fe:ee:ff", 43.2));
-    data_points.push_back(std::make_pair<std::string, double>("01:23:dd:3e:4c:cc", 99.9));
+    std::vector<std::pair<std::string, int32_t>> data_points;
+    data_points.push_back(std::make_pair<std::string, int32_t>("ee:44:43:a5:ff:ef", 23));
+    data_points.push_back(std::make_pair<std::string, int32_t>("11:65:d4:fe:ee:ff", 43));
+    data_points.push_back(std::make_pair<std::string, int32_t>("01:23:dd:3e:4c:cc", 99));
 
     data_store_->CreateDeviceTable(device_id);
     EXPECT_TRUE(data_store_->InsertRSSIReadings(device_id, data_points));
     std::string expected_sql = "INSERT INTO dev_" + device_id + " (mac_addr, rssi) VALUES"
-                                                                "('ee:44:43:a5:ff:ef',23.66),('11:65:d4:fe:ee:ff',43.2)"
-                                                                ",('01:23:dd:3e:4c:cc',99.9);";
+                                                                "('ee:44:43:a5:ff:ef',23),('11:65:d4:fe:ee:ff',43)"
+                                                                ",('01:23:dd:3e:4c:cc',99);";
     EXPECT_EQ(expected_sql, GetExecutingSql());
     data_store_->Close();
     std::remove("db");
@@ -309,12 +309,12 @@ TEST_F(DataStoreFixture, ReadDistinctMacAddrs_WillSetUniqueMacAddrsInDeviceTable
 {
     data_store_->Init("db");
     std::string device_id = "4004";
-    std::vector<std::pair<std::string, double>> data_points;
+    std::vector<std::pair<std::string, int32_t>> data_points;
     for (int i = 0; i < 5; ++i)
     {
-        data_points.push_back(std::make_pair<std::string, double>("ee:44:43:a5:ff:ef", 23.66));
-        data_points.push_back(std::make_pair<std::string, double>("11:65:d4:fe:ee:ff", 43.2));
-        data_points.push_back(std::make_pair<std::string, double>("01:23:dd:3e:4c:cc", 99.9));
+        data_points.push_back(std::make_pair<std::string, int32_t>("ee:44:43:a5:ff:ef", 23));
+        data_points.push_back(std::make_pair<std::string, int32_t>("11:65:d4:fe:ee:ff", 43));
+        data_points.push_back(std::make_pair<std::string, int32_t>("01:23:dd:3e:4c:cc", 99));
     }
 
     data_store_->CreateDeviceTable(device_id);


### PR DESCRIPTION
## Description
Add new helper function to `DataStore`. As mentioned and requested by @lexious89 , I have added these changes and it provides the appropriate dataset needed for calculating device location. 

The newly added function are best used alongside `GetDistinctMacAddrs` function. 
A typical use will be:
* Use `GetDistinctMacAddrs` to fetch all unique mac_addrs for a specific device.
* Use `GetRssiSeriesData` to get a list of `rssi` values for a particular `mac_addr`, by specifying  `device_name` and `mac_addr`
* If needed, a matrix dataset of rssi value can be returned is more than one `mac_addr` is specified. See return value example - 
`{  
 ("ee:44:43:a5:ff:ef", { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }),
     ("11:65:d4:fe:ee:ff", { 100, 103, 106, 109, 112, 115, 118, 121, 124, 127 }),
     ("01:23:dd:3e:4c:cc", { 0, 2, 4, 6, 8, 10, 12, 14, 16, 18 })
}` 


This pull request also include `RSSI` datatype change from `double` to `int32_t`

## Solved issue(s)
#61 
#62 
