### PR TITLE
Fix WiFi Module power pin according to schematics

### DIFF
--- a/ins-node/src/power_controller/power_controller.ino
+++ b/ins-node/src/power_controller/power_controller.ino
@@ -34,7 +34,7 @@ enum PowerState {
 
 const uint8_t TX_PIN = PB0;
 const uint8_t RX_PIN = PB1;
-const uint8_t WIFI_MODULE_PIN = PB2; // Controls the power to the Wifi module
+const uint8_t WIFI_MODULE_PIN = PB3; // Controls the power to the Wifi module
 
 WatchDogTimeout currentTimeout = WDT_8sec; // Current watchdog timeout
 


### PR DESCRIPTION
## Description
The wrong pin was used for controlling the WiFi module. This pull introduces the correct pin according to the current schematics.

## Solved issue(s)
Fixes #66 