### PR TITLE
Fix negative voltage when Wifi module is off

### DIFF
--- a/ins-node/src/power_controller/power_controller.ino
+++ b/ins-node/src/power_controller/power_controller.ino
@@ -156,19 +156,20 @@ bool stayAsleepFor(const unsigned long totalSleepDuration) {
 */
 void notifyWifiShutdown() {
   // Send a short pulse
+  pinMode(TX_PIN, OUTPUT);
   digitalWrite(TX_PIN, HIGH);
   delayMicroseconds(5);
   digitalWrite(TX_PIN, LOW);
+  pinMode(TX_PIN, INPUT);
 }
 
 void setup() {
   // Setup I/O pins
   pinMode(RX_PIN, INPUT);
-  pinMode(TX_PIN, OUTPUT);
+  pinMode(TX_PIN, INPUT); // Set it as an input to avoid strange parasitic voltages
   pinMode(WIFI_MODULE_PIN, OUTPUT);
 
   // Initialize the pin states
-  digitalWrite(TX_PIN, LOW);
   digitalWrite(WIFI_MODULE_PIN, LOW);
 
   setupRXInterrupt();

--- a/ins-node/test/ut/power_controller_test.cc
+++ b/ins-node/test/ut/power_controller_test.cc
@@ -53,11 +53,10 @@ TEST_F(PowerControllerFixture, setup_whenSetupIsCalled_willInitializePins)
 {
     // Pins are initialized as inputs or outputs
     EXPECT_CALL(*arduinoMock, pinMode(RX_PIN, INPUT));
-    EXPECT_CALL(*arduinoMock, pinMode(TX_PIN, OUTPUT));
+    EXPECT_CALL(*arduinoMock, pinMode(TX_PIN, INPUT));
     EXPECT_CALL(*arduinoMock, pinMode(WIFI_MODULE_PIN, OUTPUT));
 
     // Output pin initial states are set
-    EXPECT_CALL(*arduinoMock, digitalWrite(TX_PIN, LOW));
     EXPECT_CALL(*arduinoMock, digitalWrite(WIFI_MODULE_PIN, LOW));
 
     setup();


### PR DESCRIPTION
## Description
When the WiFi module was turned off, the power controller did not have
a common ground with the wifi module, which would cause the relative
voltage (from the wifi module's perspective) to be negative. This would
strangely result in a constant low voltage of around 1-1.5 volts being
present at the VCC and GND pins of the WiFi module. This resulted in
weird behavior and overall needlessly higher power consumption.

The fix involves the PB0 pin being set to INPUT so to avoid this noise
on the Wifi module's side. Whenever we want to transmit a pulse through
the PB0 pin, we set it as OUTPUT (then the WiFi module is ON so there is
no problem) and when we are done we set it back to INPUT again.

## Solved issue(s)
Fixes #65 