### PR TITLE
Use multiple SSIDs for positioning

### DIFF
--- a/ins-node/src/wifi_module/wifi_credentials.h
+++ b/ins-node/src/wifi_module/wifi_credentials.h
@@ -9,7 +9,7 @@
 
 const char internetSSID[] = "SSID to connect";
 const char password[] = "yourP4sSw0rD";
-String positioningSSID = "SSID for positioning";
+std::set<String> positioningNetworks = {"SSID-a", "SSID-b"};
 const uint16_t HTTP_PORT = 8050; // ins-server port number
 const char SERVER_IP[] = "192.168.0.2"; // ins-server IP address
 

--- a/ins-node/src/wifi_module/wifi_module.ino
+++ b/ins-node/src/wifi_module/wifi_module.ino
@@ -2,6 +2,7 @@
 #include <math.h>
 #include <vector>
 #include <utility>
+#include <set>
 #include <ESP8266WiFi.h>
 #include "wifi_credentials.h"
 
@@ -36,7 +37,9 @@ std::vector<std::pair <String, int32_t>> getDatapoints() {
   // Scan the surrounding networks and get how many were found
   auto networksFound = wifi.scanNetworks();
   for (auto i = 0; i < networksFound; ++i) {
-    if (wifi.SSID(i) == positioningSSID) {
+    // Check if some of the networks should be used for positioning
+    bool validNetwork = positioningNetworks.find(wifi.SSID(i)) != positioningNetworks.end();
+    if (validNetwork) {
       datapoints.push_back(getNetworkContext(i));
     }
   }

--- a/ins-node/test/ut/wifi_module_test.cc
+++ b/ins-node/test/ut/wifi_module_test.cc
@@ -141,7 +141,8 @@ TEST_F(WifiModuleFixture, getDatapoints_whenSSIDMatch_willReturnValid)
         EXPECT_CALL(*esp8266Mock, SSID(_))
             .Times(networksFound - accessPointsFound)
             .WillRepeatedly(Return("SomeOtherSSID"));
-        EXPECT_CALL(*esp8266Mock, SSID(_)).Times(accessPointsFound).WillRepeatedly(Return(positioningSSID));
+        // Return one of the SSID's used for positioning
+        EXPECT_CALL(*esp8266Mock, SSID(_)).Times(accessPointsFound).WillRepeatedly(Return(*positioningNetworks.begin()));
     }
     EXPECT_CALL(*esp8266Mock, BSSIDstr(_)).WillOnce(Return(expectedMAC[0])).WillOnce(Return(expectedMAC[1]));
     EXPECT_CALL(*esp8266Mock, RSSI(_)).WillOnce(Return(expectedRSSI[0])).WillOnce(Return(expectedRSSI[1]));
@@ -238,7 +239,8 @@ TEST_F(WifiModuleFixture, loop_whenDatapointsFound_willTransmit)
         EXPECT_CALL(*esp8266Mock, SSID(_))
             .Times(networksFound - accessPointsFound)
             .WillRepeatedly(Return("SomeOtherSSID"));
-        EXPECT_CALL(*esp8266Mock, SSID(_)).Times(accessPointsFound).WillRepeatedly(Return(positioningSSID));
+        // Return one of the SSID's used for positioning
+        EXPECT_CALL(*esp8266Mock, SSID(_)).Times(accessPointsFound).WillRepeatedly(Return(*positioningNetworks.begin()));
     }
     EXPECT_CALL(*esp8266Mock, BSSIDstr(_)).WillOnce(Return(expectedMAC[0])).WillOnce(Return(expectedMAC[1]));
     EXPECT_CALL(*esp8266Mock, RSSI(_)).WillOnce(Return(expectedRSSI[0])).WillOnce(Return(expectedRSSI[1]));
@@ -271,7 +273,8 @@ TEST_F(WifiModuleFixture, loop_whenTransmissionFails_willStopTransmitting)
         EXPECT_CALL(*esp8266Mock, SSID(_))
             .Times(networksFound - accessPointsFound)
             .WillRepeatedly(Return("SomeOtherSSID"));
-        EXPECT_CALL(*esp8266Mock, SSID(_)).Times(accessPointsFound).WillRepeatedly(Return(positioningSSID));
+        // Return one of the SSID's used for positioning
+        EXPECT_CALL(*esp8266Mock, SSID(_)).Times(accessPointsFound).WillRepeatedly(Return(*positioningNetworks.begin()));
     }
     EXPECT_CALL(*esp8266Mock, BSSIDstr(_)).WillOnce(Return(expectedMAC[0])).WillOnce(Return(expectedMAC[1]));
     EXPECT_CALL(*esp8266Mock, RSSI(_)).WillOnce(Return(expectedRSSI[0])).WillOnce(Return(expectedRSSI[1]));


### PR DESCRIPTION
## Description
In order to increase the accuracy and availability of the system we would like to allow multiple SSID's to be used for positioning, instead of just a single one.

## Solved issue(s)
#80
