### PR TITLE
Handle interrupt signal for graceful shutdown

### DIFF
--- a/server/src/lib_wrapper.cpp
+++ b/server/src/lib_wrapper.cpp
@@ -15,11 +15,11 @@ void HttpEndpointSetHandler(std::shared_ptr<Pistache::Http::Endpoint> http_end_p
 
 void HttpEndpointServe(std::shared_ptr<Pistache::Http::Endpoint> http_end_point)
 {
-    http_end_point->serve();
+    http_end_point->serveThreaded();
 }
 
 void HttpEndpointShutdown(std::shared_ptr<Pistache::Http::Endpoint> http_end_point)
 {
     http_end_point->shutdown();
 }
-}
+} //!ins_service

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -3,7 +3,7 @@
 //
 
 #include "ins_service.hpp"
-#include <signal.h>
+#include <csignal>
 
 volatile sig_atomic_t is_server_running = 1;
 
@@ -38,8 +38,8 @@ int main(int argc, char* argv[])
     ins.Init(addr, thread_count);
 
     // Register abort & terminate signals respectively
-    signal(SIGINT, kill_server);
-    signal(SIGTERM, kill_server);
+    std::signal(SIGINT, kill_server);
+    std::signal(SIGTERM, kill_server);
 
     // start server
     ins.Start();

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -3,6 +3,14 @@
 //
 
 #include "ins_service.hpp"
+#include <signal.h>
+
+volatile sig_atomic_t is_server_running = 1;
+
+void kill_server(int sig)
+{
+    is_server_running = 0;
+}
 
 int main(int argc, char* argv[])
 {
@@ -28,6 +36,17 @@ int main(int argc, char* argv[])
 
     ins_service::IndoorNavigationService ins;
     ins.Init(addr, thread_count);
+
+    // Register abort & terminate signals respectively
+    signal(SIGINT, kill_server);
+    signal(SIGTERM, kill_server);
+
+    // start server
     ins.Start();
+
+    while (is_server_running)
+        sleep(1);
+
+    // shutdown server
     ins.Shutdown();
 }


### PR DESCRIPTION
## Description
Prior to this pull request, it is impossible to shut down the ins_server in a proper manner as one will have to manually kill the process to exit. This commit adds interrupt signal handling which helps the server exits gracefully as would be expected.

## Solved issue(s)
* Fixes #85